### PR TITLE
Monitor @imports + Remove sourcemap logic, pass the task to next loader (usually css-loader)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,6 @@ module.exports = function(content) {
 		return content;
 	}
 	var callback = this.async();
-	var resolve = this.resolve;
-	var addDependency = this.addDependency;
-	var emitWarning = this.emitWarning || function() {};
 	var query = loaderUtils.parseQuery(this.query);
 
 	var args = [];
@@ -68,53 +65,9 @@ module.exports = function(content) {
 					if(err) {
 						return callback(err);
 					}
-					processMap(cssData, JSON.parse(mapData), buildPath, callback);
-
+					callback(null, cssData, mapData);
 				});
 			});
 		}
 	}.bind(this));
-
-
-	// taken from https://github.com/webpack/source-map-loader
-	function processMap(content, map, context, callback) {
-		if(!map.sourcesContent || map.sourcesContent.length < map.sources.length) {
-			var sourcePrefix = map.sourceRoot ? map.sourceRoot + "/" : "";
-			map.sources = map.sources.map(function(s) { return sourcePrefix + s; });
-			delete map.sourceRoot;
-			var missingSources = map.sourcesContent ? map.sources.slice(map.sourcesContent.length) : map.sources;
-			async.map(missingSources, function(source, callback) {
-				resolve(context, loaderUtils.urlToRequest(source), function(err, result) {
-					if(err) {
-						emitWarning("Cannot find source file '" + source + "': " + err);
-						return callback(null, null);
-					}
-					addDependency(result);
-					fs.readFile(result, "utf-8", function(err, content) {
-						if(err) {
-							emitWarning("Cannot open source file '" + result + "': " + err);
-							return callback(null, null);
-						}
-						callback(null, {
-							source: result,
-							content: content
-						});
-					});
-				});
-			}, function(err, info) {
-				map.sourcesContent = map.sourcesContent || [];
-				info.forEach(function(res) {
-					if(res) {
-						map.sources[map.sourcesContent.length] = res.source;
-						map.sourcesContent.push(res.content);
-					} else {
-						map.sourcesContent.push(null);
-					}
-				});
-				processMap(content, map, context, callback);
-			});
-			return;
-		}
-		callback(null, content, map);
-	}
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ under copyright of Tobias Koppers @sokra
 */
 
 var // imports
-	child_process = require('child_process')
+	child_process = require('child_process'),
+	sassGraph = require('sass-graph'),
 	fs = require('fs'),
 	os = require('os'),
 	path = require('path'),
@@ -23,6 +24,10 @@ module.exports = function(content) {
 	}
 	var callback = this.async();
 	var query = loaderUtils.parseQuery(this.query);
+	var self = this;
+	sassGraph.parseFile(this.resource).visitDescendents(this.resource, function(path) {
+		self.addDependency(path);
+	})
 
 	var args = [];
 	if(query.compass) {
@@ -47,7 +52,6 @@ module.exports = function(content) {
 	var cachePath = path.normalize(buildPath + '/sass-cache/');
 	var outputPath = query.outputFile ?  path.normalize(buildPath + '/' + query.outputFile) : buildPath + (Math.random(0, 1000) + path.parse(this.resource).name) + '.css' ;
 	var outputMapPath = outputPath + '.map';
-
 	args = args.concat(['--cache-location=' + cachePath, this.resource, outputPath]);
 	var sass = process.platform === "win32" ? "sass.bat" : "sass";
 	child_process.execFile(sass, args, {cwd: this.context}, function(err, stdout, stderr) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"loader-utils": "~0.2.3",
-		"async": "~0.9.0"
+		"async": "~0.9.0",
+		"sass-graph": "~2.0.0"
 	}
 }


### PR DESCRIPTION
There is no need for sass-loader to deal with sourcemaps. The css loader already does that. We just need to pass the sourcemap string to the css loader.

This pull requests does just that.

Needed config:

```
            {
                test: /\.scss$/,
                loader: "style!css?sourceMap!ruby-sass"
            },
```

or like this:

```
            {
                test: /\.scss$/,
                loader: ExtractTextPlugin.extract("style", "css?sourceMap!ruby-sass")
            },
```
