### PR TITLE
Add option to set directory to run sass in (context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ Controls the --require argument.
 Specify a custom build path. If not given the sass and cache files will be compiled in a temporary directory (os.tmpdir() + '/ruby-sass-loader')
 
 #### outputFile
-Specify a custom output filename. If not specified the sass and cache files will be compiled into 'out.css' and 'out.css.map'
+Specify a custom output filename. If not specified the sass and cache files will be compiled into 'out.css' and 'out.css.map'sass-loader')
 
+#### context
+Specify a custom context, which is a working directory for sass process. By default it is a directory where your entry file is located.
 
 ### Simple example
 

--- a/index.js
+++ b/index.js
@@ -22,8 +22,12 @@ module.exports = function(content) {
 	var callback = this.async();
 	var addDependency = this.addDependency.bind(this);
 	var query = loaderUtils.parseQuery(this.query);
+	var context = this.context;
 
 	var args = [];
+	if(query.context) {
+		context = query.context;
+	}
 	if(query.compass) {
 		args.push('--compass');
 	}
@@ -53,7 +57,7 @@ module.exports = function(content) {
 
 	args = args.concat(['--cache-location=' + cachePath, this.resource, outputPath]);
 	var sass = process.platform === "win32" ? "sass.bat" : "sass";
-	child_process.execFile(sass, args, {cwd: this.context}, function(err, stdout, stderr) {
+	child_process.execFile(sass, args, {cwd: context}, function(err, stdout, stderr) {
 		if(err) {
 			callback(err);
 		} else {


### PR DESCRIPTION
On my current project had a problem where ruby-sass-loader couldn't find an image used in inline-image(), but regular commanline sass worked. Error message was like this: 

```
 ERROR in ./~/css-loader?{"sourceMap":true}!./~/ruby-sass-loader?{"includePaths": ... ,"buildPath":"/home/larionov/projects/ui-components-es6/dist/","outputFile":"air.global.css","compass":true,"sourceMap":true}!./src/styles/themes/air/main.scss
     Module build failed: Error: Command failed: sass --compass --load-path=...
     Error: File not found or cannot be read: ./images/images/svg-icons/upwork-logo.svg
             on line 8 of /home/larionov/projects/ui-components-es6/src/styles/themes/air/partials/_layouts.scss
             from line 24 of /home/larionov/projects/ui-components-es6/src/styles/themes/air/main.scss
       Use --trace for backtrace.
```
 
Added option to specify working directory for sass.